### PR TITLE
Update manifest for Rev B Porting

### DIFF
--- a/smartracks-manifest.xml
+++ b/smartracks-manifest.xml
@@ -6,7 +6,6 @@
   <remote alias="repo" fetch="https://github.com/Freescale" name="githf"/>
   <remote alias="repo" fetch="https://git.toradex.com" name="tdx"/>
   <remote alias="repo" fetch="https://github.com/ni" name="ni"/>
-  <remote alias="repo" fetch="https://github.com/rauc" name="rauc"/>
   
   <default sync-j="4"/>
   


### PR DESCRIPTION
Update all bitbake recipes to the latest versions based on toradex's latest stable release. Removed meta-rauc as well.
We push these changes to a rev_b_porting branch first instead of main because if we push it to main, nibuild will break due to some core changes to linux-toradex, particularly the removal of imx8x-apalis machine and device tree. See:
https://git.toradex.com/cgit/meta-toradex-nxp.git/commit/?h=dunfell-5.x.y&id=09aa1d01d4778219d8e5c9755d35498306f13e26
https://git.toradex.com/cgit/linux-toradex.git/commit/?h=toradex_5.4-2.3.x-imx&id=86af94f1df2796e7cb4d8a4921b6d4be712f292c

This way, we can prevent our main branch from turning bad while working on Rev B porting.