### PR TITLE
Bump git hashes

### DIFF
--- a/ateccgen2-manifest.xml
+++ b/ateccgen2-manifest.xml
@@ -11,72 +11,72 @@
   <default sync-j="4"/>
 
   <!-- bitbake: Branch 2.0 -->
-  <!-- https://github.com/openembedded/bitbake/commit/0c6f86b60cfba67c20733516957c0a654eb2b44c -->
-  <project name="bitbake.git" path="layers/openembedded-core/bitbake" remote="oe" revision="0c6f86b60cfba67c20733516957c0a654eb2b44c" upstream="2.0"/>
+  <!-- https://github.com/openembedded/bitbake/commit/41b6684489d0261753344956042be2cc4adb0159 -->
+  <project name="bitbake.git" path="layers/openembedded-core/bitbake" remote="oe" revision="41b6684489d0261753344956042be2cc4adb0159" upstream="2.0"/>
 
   <!-- meta-openembedded: Branch kirkstone -->
-  <!-- https://github.com/openembedded/meta-openembedded/commit/5f120a926b0fcd55cfe7565bb7ddf23661cad498 -->
-  <project name="meta-openembedded.git" path="layers/meta-openembedded" remote="oe" revision="5f120a926b0fcd55cfe7565bb7ddf23661cad498" upstream="kirkstone"/>
+  <!-- https://github.com/openembedded/meta-openembedded/commit/529620141e773080a6a7be4615fb7993204af883 -->
+  <project name="meta-openembedded.git" path="layers/meta-openembedded" remote="oe" revision="529620141e773080a6a7be4615fb7993204af883" upstream="kirkstone"/>
 
   <!-- meta-yocto: Branch kirkstone -->
-  <!-- https://git.yoctoproject.org/cgit/cgit.cgi/meta-yocto/commit/?id=4f81a08e7b655968266211cfc943085a69865a90 -->
-  <project name="meta-yocto" path="layers/meta-yocto" remote="yocto" revision="4f81a08e7b655968266211cfc943085a69865a90" upstream="kirkstone"/>
+  <!-- https://git.yoctoproject.org/cgit/cgit.cgi/meta-yocto/commit/?id=d45be9886a9680b88ecf2f1b9717492a0df9158e -->
+  <project name="meta-yocto" path="layers/meta-yocto" remote="yocto" revision="d45be9886a9680b88ecf2f1b9717492a0df9158e" upstream="kirkstone"/>
 
   <!-- openembedded-core: Branch kirkstone -->
-  <!-- https://github.com/openembedded/openembedded-core/commit/717b9f18a51e9c9fd5a471238aa2ea4de439ef17 -->
-  <project name="openembedded-core.git" path="layers/openembedded-core" remote="oe" revision="717b9f18a51e9c9fd5a471238aa2ea4de439ef17" upstream="kirkstone"/>
+  <!-- https://github.com/openembedded/openembedded-core/commit/ea920e3c8075f3a1b79039341f8c889f6197a07f -->
+  <project name="openembedded-core.git" path="layers/openembedded-core" remote="oe" revision="ea920e3c8075f3a1b79039341f8c889f6197a07f" upstream="kirkstone"/>
 
   <!-- meta-freescale-3rdparty: Branch kirkstone -->
-  <!-- https://github.com/Freescale/meta-freescale-3rdparty/commit/fa18e5bf5abdabcc37d4bfbc3c46713cd9d19e2e -->
-  <project name="meta-freescale-3rdparty.git" path="layers/meta-freescale-3rdparty" remote="githf" revision="fa18e5bf5abdabcc37d4bfbc3c46713cd9d19e2e" upstream="kirkstone"/>
+  <!-- https://github.com/Freescale/meta-freescale-3rdparty/commit/6dbdabe09e410818dcda8801e1cbd8b68d539e63 -->
+  <project name="meta-freescale-3rdparty.git" path="layers/meta-freescale-3rdparty" remote="githf" revision="6dbdabe09e410818dcda8801e1cbd8b68d539e63" upstream="kirkstone"/>
 
   <!-- meta-freescale-distro: Branch kirkstone -->
   <!-- https://github.com/Freescale/meta-freescale-distro/commit/d5bbb487b2816dfc74984a78b67f7361ce404253 -->
   <project name="meta-freescale-distro.git" path="layers/meta-freescale-distro" remote="githf" revision="d5bbb487b2816dfc74984a78b67f7361ce404253" upstream="kirkstone"/>
 
   <!-- meta-freescale: Branch kirkstone -->
-  <!-- https://github.com/Freescale/meta-freescale/commit/c90c2c2f18badca14439e01bd3e891d1fd99b255 -->
-  <project name="meta-freescale.git" path="layers/meta-freescale" remote="githf" revision="c90c2c2f18badca14439e01bd3e891d1fd99b255" upstream="kirkstone"/>
+  <!-- https://github.com/Freescale/meta-freescale/commit/3e9ef23d98aa842cf84251a27c9b8dde8925ea61 -->
+  <project name="meta-freescale.git" path="layers/meta-freescale" remote="githf" revision="3e9ef23d98aa842cf84251a27c9b8dde8925ea61" upstream="kirkstone"/>
 
   <!-- meta-toradex-bsp-common: Branch kirkstone-6.x.y -->
-  <!-- https://git.toradex.com/cgit/meta-toradex-bsp-common.git/commit/?id=90777b9695c720c271221e0b73c55e21b6eb64a7 -->
-  <project name="meta-toradex-bsp-common.git" path="layers/meta-toradex-bsp-common" remote="tdx" revision="90777b9695c720c271221e0b73c55e21b6eb64a7" upstream="kirkstone-6.x.y"/>
+  <!-- https://git.toradex.com/cgit/meta-toradex-bsp-common.git/commit/?id=56e195b10849e2973130695a1917c987a4fe1813 -->
+  <project name="meta-toradex-bsp-common.git" path="layers/meta-toradex-bsp-common" remote="tdx" revision="56e195b10849e2973130695a1917c987a4fe1813" upstream="kirkstone-6.x.y"/>
 
   <!-- meta-toradex-nxp: Branch kirkstone-6.x.y -->
-  <!-- https://git.toradex.com/cgit/meta-toradex-nxp.git/commit/?id=378db7384cbdb84b4dead84af0b0a05c36bd65fe -->
-  <project name="meta-toradex-nxp.git" path="layers/meta-toradex-nxp" remote="tdx" revision="378db7384cbdb84b4dead84af0b0a05c36bd65fe" upstream="kirkstone-6.x.y"/>
+  <!-- https://git.toradex.com/cgit/meta-toradex-nxp.git/commit/?id=021194ccd174fdb2b939636c40a2b518f51d6e7a -->
+  <project name="meta-toradex-nxp.git" path="layers/meta-toradex-nxp" remote="tdx" revision="021194ccd174fdb2b939636c40a2b518f51d6e7a" upstream="kirkstone-6.x.y"/>
 
   <!-- meta-toradex-ti: Branch kirkstone-6.x.y -->
-  <!-- https://git.toradex.com/cgit/meta-toradex-ti.git/commit/?id=0b261c143751f752303361fcd0f31fdbd0b18554 -->
-  <project name="meta-toradex-ti.git" path="layers/meta-toradex-ti" remote="tdx" revision="0b261c143751f752303361fcd0f31fdbd0b18554" upstream="kirkstone-6.x.y"/>
+  <!-- https://git.toradex.com/cgit/meta-toradex-ti.git/commit/?id=bd357480c60445012b0ab8b09ebec82184a3aa2d -->
+  <project name="meta-toradex-ti.git" path="layers/meta-toradex-ti" remote="tdx" revision="bd357480c60445012b0ab8b09ebec82184a3aa2d" upstream="kirkstone-6.x.y"/>
 
   <!-- meta-arm: Branch kirkstone -->
-  <!-- https://git.yoctoproject.org/cgit/cgit.cgi/meta-arm/commit/?id=96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd -->
-  <project name="meta-arm" path="layers/meta-arm" remote="yocto" revision="96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd" upstream="kirkstone"/>
+  <!-- https://git.yoctoproject.org/cgit/cgit.cgi/meta-arm/commit/?id=b187fb9232ca0a6b5f8f90b4715958546fc41d73 -->
+  <project name="meta-arm" path="layers/meta-arm" remote="yocto" revision="b187fb9232ca0a6b5f8f90b4715958546fc41d73" upstream="kirkstone"/>
 
   <!-- meta-ti: Branch kirkstone -->
-  <!-- https://git.yoctoproject.org/cgit/cgit.cgi/meta-ti/commit/?id=1743b0101984094cb74fed9105afd59de110a044 -->
-  <project name="meta-ti" path="layers/meta-ti" remote="yocto" revision="1743b0101984094cb74fed9105afd59de110a044" upstream="kirkstone"/>
+  <!-- https://git.yoctoproject.org/cgit/cgit.cgi/meta-ti/commit/?id=1ccba22923b1c0ce3558075f3de3846ba983155c -->
+  <project name="meta-ti" path="layers/meta-ti" remote="yocto" revision="1ccba22923b1c0ce3558075f3de3846ba983155c" upstream="kirkstone"/>
 
   <!-- meta-qt5: Branch kirkstone -->
   <!-- https://github.com/meta-qt5/meta-qt5/commit/bff5bd937f0776166e81a63f3dd39ede348ef758 -->
   <project name="meta-qt5.git" path="layers/meta-qt5" remote="githq" revision="bff5bd937f0776166e81a63f3dd39ede348ef758" upstream="kirkstone"/>
 
   <!-- meta-toradex-demos: Branch kirkstone-6.x.y -->
-  <!-- https://git.toradex.com/cgit/meta-toradex-demos.git/commit/?id=cd885de817405c00298500f90af689612757aebb -->
-  <project name="meta-toradex-demos.git" path="layers/meta-toradex-demos" remote="tdx" revision="cd885de817405c00298500f90af689612757aebb" upstream="kirkstone-6.x.y"/>
+  <!-- https://git.toradex.com/cgit/meta-toradex-demos.git/commit/?id=ac087af8ca07b847e48e9f321a1e606b61b156c1 -->
+  <project name="meta-toradex-demos.git" path="layers/meta-toradex-demos" remote="tdx" revision="ac087af8ca07b847e48e9f321a1e606b61b156c1" upstream="kirkstone-6.x.y"/>
 
   <!-- meta-toradex-distro: Branch kirkstone-6.x.y -->
-  <!-- https://git.toradex.com/cgit/meta-toradex-distro.git/commit/?id=50942e30e5d81e3894fd4db3d8b79e2cb53d2a9b -->
-  <project name="meta-toradex-distro.git" path="layers/meta-toradex-distro" remote="tdx" revision="50942e30e5d81e3894fd4db3d8b79e2cb53d2a9b" upstream="kirkstone-6.x.y"/>
+  <!-- https://git.toradex.com/cgit/meta-toradex-distro.git/commit/?id=491e249099a36c2eb7f8c0192f100265c1eae0b1 -->
+  <project name="meta-toradex-distro.git" path="layers/meta-toradex-distro" remote="tdx" revision="491e249099a36c2eb7f8c0192f100265c1eae0b1" upstream="kirkstone-6.x.y"/>
 
   <!-- meta-mender: Branch kirkstone -->
-  <!-- https://github.com/mendersoftware/meta-mender/commit/88d370ba5cab12822d63d4aba9025d5569b6be27 -->
-  <project name="meta-mender" path="layers/meta-mender" remote="mender" revision="88d370ba5cab12822d63d4aba9025d5569b6be27" upstream="kirkstone"/>
+  <!-- https://github.com/mendersoftware/meta-mender/commit/684fa23a731208b4f813d36eac8f034fe646f19c -->
+  <project name="meta-mender" path="layers/meta-mender" remote="mender" revision="684fa23a731208b4f813d36eac8f034fe646f19c" upstream="kirkstone"/>
 
   <!-- meta-mender-community: Branch kirkstone -->
-  <!-- https://github.com/mendersoftware/meta-mender-community/commit/8a2c2bc31e04e110a64d295d6940e812a2d74ad3 -->
-  <project name="meta-mender-community" path="layers/meta-mender-community" remote="mender" revision="8a2c2bc31e04e110a64d295d6940e812a2d74ad3" upstream="kirkstone"/>
+  <!-- https://github.com/mendersoftware/meta-mender-community/commit/defe3aa1a72e6663adc6a67347687e34d3798845 -->
+  <project name="meta-mender-community" path="layers/meta-mender-community" remote="mender" revision="defe3aa1a72e6663adc6a67347687e34d3798845" upstream="kirkstone"/>
 
   <!-- meta-ateccgen2: Branch main -->
   <project name="meta-ateccgen2.git" path="layers/meta-ateccgen2" remote="ni" revision="main" upstream="main">


### PR DESCRIPTION
Bump git hashes to latest pinned according to [toradex-manifest](https://git.toradex.com/cgit/toradex-manifest.git/commit/?h=kirkstone-6.x.y&id=99ff72f55d9b45c0e8f02603351b4b5f09b07e13).

ateccgen2-minimal-image built and installed into RCU + fanout board setup without issues. 