### PR TITLE
Trigger 24.3.0 CI based on changes to release branch

### DIFF
--- a/stub.yml
+++ b/stub.yml
@@ -6,7 +6,7 @@ variables:
   - group: AteCoreConfigGen2PipelineVariables
 
 trigger:
-- main
+- release/24.3.0
 
 pr: none
 


### PR DESCRIPTION
Just noticed that 24.3.0 branch stub trigger points to main instead of the release branch. This should be the corresponding release branch name instead. This doesn't affect the RCU image build for 24.3.0 if the build is triggered manually, but CI wouldn't work correctly if left unchanged.